### PR TITLE
Установка и использование CSI драйвера

### DIFF
--- a/kubernetes-csi/README.md
+++ b/kubernetes-csi/README.md
@@ -1,0 +1,61 @@
+# Репозиторий для выполнения домашних заданий курса "Инфраструктурная платформа на основе Kubernetes-2024-10" 
+
+## Домашнее задание №12. Установка и использование CSI драйвера
+
+Домашнее задание выполнено в `Managed Service for Kubernetes` в `Yandex Cloud`
+
+```bash
+kubectl get node
+
+NAME                        STATUS   ROLES    AGE   VERSION
+cl1g9c50r6l4ccs2reg5-eqod   Ready    <none>   85s   v1.29.1
+```
+
+1. Создан бакет в S3 object storage Yandex cloud.
+```bash
+yc storage bucket list  
++-------------------+----------------------+------------+-----------------------+---------------------+
+|       NAME        |      FOLDER ID       |  MAX SIZE  | DEFAULT STORAGE CLASS |     CREATED AT      |
++-------------------+----------------------+------------+-----------------------+---------------------+
+|    some-bucket    | -------------------- | 1073741824 | STANDARD              | 2025-02-03 18:09:58 |
++-------------------+----------------------+------------+-----------------------+---------------------+
+```
+2. Создан сервис аккаунт с правами `storage.editor` и статический ключ для него.
+3. Создан [секрет](./secret.yaml) со статическим ключом и его id.
+4. Создан [storageClass](./storageClass.yaml)
+5. Из репозитория `yandex-cloud/k8s-csi-s3` установлен S3 CSI драйвер.
+```bash
+git clone https://github.com/yandex-cloud/k8s-csi-s3.git
+```
+```bash
+kubectl apply -f secret.yaml && \
+kubectl apply -f k8s-csi-s3/deploy/kubernetes/provisioner.yaml && \
+kubectl apply -f k8s-csi-s3/deploy/kubernetes/driver.yaml && \
+kubectl apply -f k8s-csi-s3/deploy/kubernetes/csi-s3.yaml && \
+kubectl apply -f storageClass.yaml
+```
+6. Создан и применен манифест [persistentVolumeClaim](./pvc.yaml) с ранее созданным storageClass для динамического создания persistentVolume.
+```bash
+kubectl apply -f pvc.yaml
+```
+```bash
+kubectl get pvc -n default csi-s3-pvc-dynamic  
+NAME                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
+csi-s3-pvc-dynamic   Bound    pvc-0e8035ae-00ac-47ff-be7e-5e70c5dc3f70   100Mi      RWX            csi-s3         <unset>                 6m9s
+```
+```bash
+s3cmd ls s3://some-bucket
+DIR  s3://some-bucket/pvc-0e8035ae-00ac-47ff-be7e-5e70c5dc3f70/
+```
+7. Создан [манифест pod](./pod.yaml), использующий созданный PVC в качестве volume, смонтированного в `/mnt/s3`:
+```bash
+kubectl apply -f pod.yaml
+```
+```bash
+kubectl exec -it csi-s3-test-alpine -- touch /mnt/s3/test.txt
+```
+```bash
+s3cmd ls s3://some-bucket/pvc-0e8035ae-00ac-47ff-be7e-5e70c5dc3f70/
+2025-02-03 19:29       DIROBJ  s3://some-bucket/pvc-0e8035ae-00ac-47ff-be7e-5e70c5dc3f70/
+2025-02-03 19:52            0  s3://some-bucket/pvc-0e8035ae-00ac-47ff-be7e-5e70c5dc3f70/test.txt
+```

--- a/kubernetes-csi/pod.yaml
+++ b/kubernetes-csi/pod.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: csi-s3-test-alpine
+  namespace: default
+spec:
+  containers:
+  - name: csi-s3-test-nginx
+    image: alpine:3.21.2
+    command: ["sleep", "300"]
+    volumeMounts:
+      - mountPath: /mnt/s3
+        name: s3
+  volumes:
+  - name: s3
+    persistentVolumeClaim:
+      claimName: csi-s3-pvc-dynamic
+      readOnly: false

--- a/kubernetes-csi/pvc.yaml
+++ b/kubernetes-csi/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-s3-pvc-dynamic
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: csi-s3

--- a/kubernetes-csi/secret.yaml
+++ b/kubernetes-csi/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: kube-system
+  name: csi-s3-secret
+stringData:
+  accessKeyID: <key_id>
+  secretAccessKey: <key>
+  endpoint: https://storage.yandexcloud.net

--- a/kubernetes-csi/storageClass.yaml
+++ b/kubernetes-csi/storageClass.yaml
@@ -1,0 +1,18 @@
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: csi-s3
+provisioner: ru.yandex.s3.csi
+parameters:
+  mounter: geesefs
+  options: "--memory-limit=1000 --dir-mode=0777 --file-mode=0666"
+  bucket: "some-bucket"
+  csi.storage.k8s.io/provisioner-secret-name: csi-s3-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+  csi.storage.k8s.io/controller-publish-secret-name: csi-s3-secret
+  csi.storage.k8s.io/controller-publish-secret-namespace: kube-system
+  csi.storage.k8s.io/node-stage-secret-name: csi-s3-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: kube-system
+  csi.storage.k8s.io/node-publish-secret-name: csi-s3-secret
+  csi.storage.k8s.io/node-publish-secret-namespace: kube-system


### PR DESCRIPTION
# Выполнено ДЗ № 12

 - [x] Основное ДЗ

## В процессе сделано:
 - В Yandex Cloud развернут кластер kubernetes и создан s3 бакет для использования в качестве persistent хранилища данных подов;
 - Для доступа CSI драйвера к бакету создан секрет с ключом сервис аккаунта, имеющего доступ к бакету;
 - Установлен S3 CSI драйвер, создан storageClass, использующий его;
 - Созданы манифесты PVC и пода, использующего этот PVC, для проверки записи данных из пода в объектное хранилище.
Пошаговое описание и вывод команд в файле: https://github.com/Kuber-2024-10OTUS/omaksimov_repo/blob/kubernetes-csi/kubernetes-csi/README.md

## Как проверить работоспособность:
 - В директории kubernetes-csi склонированного репозитория выполнить поочередно команды, описанные в файле: https://github.com/Kuber-2024-10OTUS/omaksimov_repo/blob/kubernetes-csi/kubernetes-csi/README.md

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
